### PR TITLE
Optimization: do fewer polymorphic comparisons

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -75,7 +75,9 @@ let add_utf_8 buffer c =
 
 let format_char = Printf.sprintf "U+%04X"
 
-let is_in_range lower upper c = c >= lower && c <= upper
+(* Type constraints are necessary to avoid polymorphic comparison, which would
+   greatly reduce performance: https://github.com/aantron/markup.ml/pull/15. *)
+let is_in_range (lower : int) (upper : int) c = c >= lower && c <= upper
 
 (* HTML 8.2.2.5. *)
 let is_control_character = function


### PR DESCRIPTION
FYI PR for the record. I downloaded the [OCaml subreddit page](https://www.reddit.com/r/ocaml/). Running [`measure.ml`](https://gist.github.com/aantron/f9c98ea4a682c19c71a247ae5dd1e608) on it,

```
ocamlfind opt -linkpkg -package unix -package markup measure.ml
./a.out ocaml-reddit.html
```

gave 40ms for parsing before the patch, and 30ms after. From the commit message:

```
Common.is_in_range is called several times by Common.is_valid_html_char,
which is called on each Unicode character read by Markup.ml - that is,
on nearly each byte, in the case of UTF-8.

Before this commit, Common.is_in_range ran OCaml's polymorphic
comparison function, which is notoriously slow.
```

cc @copy I'll look for additional simple fixes – some seem to involve comparison in `List.mem`. Let me know if you start working on any specific optimizations, so we don't duplicate effort :)