### PR TITLE
Speed up entity lookup using a trie

### DIFF
--- a/src/trie.ml
+++ b/src/trie.ml
@@ -1,0 +1,79 @@
+(* This file is part of Markup.ml, released under the BSD 2-clause license. See
+   doc/LICENSE for details, or visit https://github.com/aantron/markup.ml. *)
+
+(* Tries. These aren't fully functional nor fully mutable. To accumulate a trie,
+   it is necessary to retain the latest result of [add]. However, previous tries
+   become invalid after [add]. *)
+
+type 'a trie =
+  | Empty
+  | Leaf of 'a
+  | Node of 'a option * 'a trie array
+
+let lower_limit = Char.code '0'
+let upper_limit = Char.code 'z'
+let array_size = upper_limit - lower_limit + 1
+
+let create () =
+  Empty
+
+let edge_index c =
+  Char.code c - lower_limit
+
+let add key value trie =
+  let rec traverse index trie =
+    if index >= String.length key then
+      match trie with
+      | Empty | Leaf _ -> Leaf value
+      | Node (_, children) -> Node (Some value, children)
+
+    else
+      let edge_index = edge_index key.[index] in
+      let value', children, current_child =
+        match trie with
+        | Empty -> None, None, Empty
+        | Leaf v -> Some v, None, Empty
+        | Node (v, children) -> v, Some children, children.(edge_index)
+      in
+      let child = traverse (index + 1) current_child in
+      let children =
+        match children with
+        | None ->
+          Array.init array_size (fun i ->
+            if i = edge_index then child else Empty)
+        | Some children ->
+          children.(edge_index) <- child;
+          children
+      in
+      Node (value', children)
+  in
+
+  traverse 0 trie
+
+type 'a match_ =
+  | No
+  | Yes of 'a
+  | Prefix
+  | Multiple of 'a
+
+let matches = function
+  | Empty -> No
+  | Leaf v -> Yes v
+  | Node (None, _) -> Prefix
+  | Node (Some v, _) -> Multiple v
+
+let advance c = function
+  | Empty | Leaf _ -> Empty
+  | Node (_, children) ->
+    if c < lower_limit || c > upper_limit then Empty
+    else children.(c - lower_limit)
+
+let guess_memory_usage trie =
+  let rec accumulate words = function
+    | Empty -> words + 1
+    | Leaf _ -> words + 2
+    | Node (_, children) ->
+      let words = words + 4 + Array.length children in
+      Array.fold_left accumulate words children
+  in
+  accumulate 0 trie

--- a/test/test.ml
+++ b/test/test.ml
@@ -9,6 +9,7 @@ let suite =
     Test_stream_io.tests;
     Test_encoding.tests;
     Test_input.tests;
+    Test_trie.tests;
     Test_xml_tokenizer.tests;
     Test_xml_parser.tests;
     Test_xml_writer.tests;

--- a/test/test_trie.ml
+++ b/test/test_trie.ml
@@ -1,0 +1,97 @@
+(* This file is part of Markup.ml, released under the BSD 2-clause license. See
+   doc/LICENSE for details, or visit https://github.com/aantron/markup.ml. *)
+
+open OUnit2
+
+let singleton w value =
+  Trie.create () |> Trie.add w value
+
+let advance w trie =
+  let rec loop index trie =
+    if index >= String.length w then trie
+    else loop (index + 1) (Trie.advance (Char.code w.[index]) trie)
+  in
+  loop 0 trie
+
+let assert_matches trie w status =
+  assert_equal (Trie.matches (advance w trie)) status
+
+let tests = [
+  ("trie.empty" >:: fun _ ->
+    let trie = Trie.create () in
+    assert_equal (Trie.matches trie) Trie.No);
+
+  ("trie.one-character" >:: fun _ ->
+    let trie = singleton "a" 0 in
+    assert_matches trie "" Trie.Prefix;
+    assert_matches trie "a" (Trie.Yes 0);
+    assert_matches trie "b" Trie.No);
+
+  ("trie.simple-word" >:: fun _ ->
+    let trie = singleton "ab" 0 in
+    assert_matches trie "" Trie.Prefix;
+    assert_matches trie "a" Trie.Prefix;
+    assert_matches trie "b" Trie.No;
+    assert_matches trie "ab" (Trie.Yes 0));
+
+  ("trie.prefix-match" >:: fun _ ->
+    let trie = Trie.create () in
+    let trie = Trie.add "a" 0 trie in
+    let trie = Trie.add "ab" 1 trie in
+    assert_matches trie "" Trie.Prefix;
+    assert_matches trie "a" (Trie.Multiple 0);
+    assert_matches trie "ab" (Trie.Yes 1));
+
+  ("trie.branching" >:: fun _ ->
+    let trie = Trie.create () in
+    let trie = Trie.add "aa" 0 trie in
+    let trie = Trie.add "ab" 1 trie in
+    assert_matches trie "" Trie.Prefix;
+    assert_matches trie "a" Trie.Prefix;
+    assert_matches trie "aa" (Trie.Yes 0);
+    assert_matches trie "ab" (Trie.Yes 1));
+
+  ("trie.unsupported-character" >:: fun _ ->
+    let trie = singleton "a" 0 in
+    assert_matches trie " " Trie.No);
+
+  ("trie.advance-no-match" >:: fun _ ->
+    let trie = singleton "a" 0 in
+    assert_matches trie "a" (Trie.Yes 0);
+    assert_matches trie "aa" Trie.No;
+    assert_matches trie "aaa" Trie.No);
+
+  ("trie.empty-string" >:: fun _ ->
+    let trie = singleton "" 0 in
+    assert_matches trie "" (Trie.Yes 0));
+
+  ("trie.replace-leaf" >:: fun _ ->
+    let trie = singleton "a" 0 in
+    assert_matches trie "a" (Trie.Yes 0);
+    let trie = Trie.add "a" 1 trie in
+    assert_matches trie "a" (Trie.Yes 1));
+
+  ("trie.replace-node" >:: fun _ ->
+    let trie = singleton "ab" 0 in
+    assert_matches trie "a" Trie.Prefix;
+    let trie = Trie.add "a" 1 trie in
+    assert_matches trie "a" (Trie.Multiple 1);
+    let trie = Trie.add "a" 2 trie in
+    assert_matches trie "a" (Trie.Multiple 2));
+
+  ("trie.memory_usage" >:: fun _ ->
+    let trie = singleton "ab" 0 in
+    let expected_nodes = 2 in
+    let expected_leaves = 1 in
+    let expected_empty_leaves =
+      expected_nodes * Trie.array_size
+      - expected_leaves
+      - (expected_nodes - 1)
+    in
+    let expected_machine_word_count =
+      expected_nodes * (4 + Trie.array_size)
+      + expected_leaves * 2
+      + expected_empty_leaves * 1
+    in
+    assert_equal (Trie.guess_memory_usage trie) expected_machine_word_count);
+]


### PR DESCRIPTION
cc @copy

Another FYI PR, in the manner of #15.

This:
- Does not affect the parsing time of the kind of input you linked me to, unfortunately. The source of that page contained at most one entity reference.
- Reduces time to parse the OCaml Reddit by about 20% – from 29 ms to 23 ms in my testing.
- Reduces time to parse `ocamldoc`s of a sizeable OCaml project by about 28 times (!!) – from 14s to 0.5s. `ocamldoc` uses a lot of `&nbsp;` for spacing, and other entities for escaping code blocks.