### PR TITLE
Do not perform entity escaping in HTML <script> tags.

### DIFF
--- a/src/markup_html_writer.ml
+++ b/src/markup_html_writer.ml
@@ -47,12 +47,15 @@ let rec starts_with_newline = function
 
 open Kstream
 
+let literal_text_elements =
+  ["style"; "script"; "xmp"; "iframe"; "noembed"; "noframes"; "plaintext"]
+
 let write signals =
   let open_elements = ref [] in
 
-  let in_script () =
+  let in_literal_text_element () =
     match !open_elements with
-      | "script" :: _ -> true
+      | element :: _ -> List.mem element literal_text_elements
       | _ -> false in
 
   let rec queue = ref next_signal
@@ -138,7 +141,7 @@ let write signals =
       | `Text ss ->
         if List.for_all (fun s -> String.length s = 0) ss then
           next_signal throw e k
-        else if in_script () then
+        else if in_literal_text_element () then
           emit_list ss throw e k
         else
           emit_list (List.map escape_text ss) throw e k

--- a/src/markup_html_writer.ml
+++ b/src/markup_html_writer.ml
@@ -50,6 +50,11 @@ open Kstream
 let write signals =
   let open_elements = ref [] in
 
+  let in_script () =
+    match !open_elements with
+      | "script" :: _ -> true
+      | _ -> false in
+
   let rec queue = ref next_signal
 
   and emit_list l throw e k =
@@ -133,6 +138,8 @@ let write signals =
       | `Text ss ->
         if List.for_all (fun s -> String.length s = 0) ss then
           next_signal throw e k
+        else if in_script () then
+          emit_list ss throw e k
         else
           emit_list (List.map escape_text ss) throw e k
 

--- a/test/test_html_writer.ml
+++ b/test/test_html_writer.ml
@@ -118,4 +118,13 @@ let tests = [
        `End_element]
       [S "<"; S "use"; S " "; S "xlink:href"; S "=\""; S "#foo"; S "\""; S ">";
        S "</"; S "use"; S ">"]);
+
+  ("html.writer.script-element" >:: fun _ ->
+     expect "script element"
+     [ `Start_element ((html_ns, "script"), []);
+       `Text ["true && false"];
+       `End_element ]
+     [ S "<"; S "script"; S ">";
+       S "true && false";
+       S "</"; S "script"; S ">" ]);
 ]


### PR DESCRIPTION
Hi,

The currently published version of markup.ml performes entity escaping throught HTML documents. Sadly, this breaks when it comes to JavaScript - a line such as

  if (x == 0 && y == 1) alert("This can't be")

has its `&&` operator escaped to `&amp;&amp;`.

Since HTML has special parsing rules for the content of `<script>` tags, I think it's correct to also special-case the output of these tags and not perform entity escaping. This pull request implements this by checking whether the top-level open tag is a script tag when outputting `Text` nodes.