### PR TITLE
Handle </html> tag as per the specification

### DIFF
--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1695,7 +1695,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
            "rtc"; "tbody"; "td"; "tfoot"; "th"; "thead"; "tr"; "body";
            "html"] (fun () ->
         push tokens v;
-        close_element l "body" after_body_mode)
+        after_body_mode ())
 
     | l, `Start ({name =
         "address" | "article" | "aside" | "blockquote" | "center" |
@@ -2612,8 +2612,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       | _, `Start {name = "html"} as v ->
         in_body_mode_rules "html" after_body_mode v
 
-      | l, `End {name = "html"} ->
-        close_element l "html" after_after_body_mode
+      | _, `End {name = "html"} ->
+        after_after_body_mode ()
 
       | l, `EOF ->
         emit_end l
@@ -2717,8 +2717,9 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       | l, `EOF ->
         emit_end l
 
-      | l, _ ->
-        report l (`Bad_content "html") !throw after_after_body_mode
+      | l, _ as v ->
+        push tokens v;
+        report l (`Bad_content "html") !throw in_body_mode
     end
 
   (* 8.2.5.4.23. *)

--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1684,7 +1684,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           ["dd"; "dt"; "li"; "optgroup"; "option"; "p"; "rb"; "rp"; "rt";
            "rtc"; "tbody"; "td"; "tfoot"; "th"; "thead"; "tr"; "body";
            "html"] (fun () ->
-        close_element l "body" after_body_mode)
+        after_body_mode ())
 
     | l, `End {name = "html"} as v ->
       if not @@ Stack.in_scope open_elements "body" then

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -39,7 +39,7 @@ let tests = [
         1, 22, S (start_element "head");
         1, 28, S  `End_element;
         1, 35, S (start_element "body");
-        1, 41, S  `End_element;
+        1, 55, S  `End_element;
         1, 55, S  `End_element];
 
     expect ~prefix:true " <!--foo--> <!DOCTYPE html>"
@@ -90,7 +90,7 @@ let tests = [
         1, 16, S (start_element "head");
         1, 16, S  `End_element;
         1, 16, S (start_element "body");
-        1, 22, S  `End_element;
+        1, 29, S  `End_element;
         1, 29, S  `End_element];
 
     expect "<!DOCTYPE html><p></p>"
@@ -224,7 +224,7 @@ let tests = [
         1,  1, S (start_element "body");
         1,  7, S (`Comment "foo");
         1, 17, S (`Text [" bar"]);
-        1, 21, S  `End_element;
+        1, 28, S  `End_element;
         1, 28, S  `End_element]);
 
   ("html.parser.body.whitespace" >:: fun _ ->
@@ -452,7 +452,7 @@ let tests = [
         1, 29, S (start_element "meta");
         1, 29, S  `End_element;
         1, 35, E (`Misnested_tag ("body", "body"));
-        1, 41, S  `End_element;
+        1, 48, S  `End_element;
         1, 48, S  `End_element]);
 
   ("html.parser.nested-html-in-body" >:: fun _ ->
@@ -473,6 +473,27 @@ let tests = [
         1, 42, S  `End_element;
         1, 42, S  `End_element]);
 
+  ("html.parser.nested-html-with-body-in-body" >:: fun _ ->
+    expect "<p><html><body><p></body><br><p>"
+      [ 1,  1, S (start_element "html");
+        1,  1, S (start_element "head");
+        1,  1, S  `End_element;
+        1,  1, S (start_element "body");
+        1,  1, S (start_element "p");
+        1,  4, E (`Misnested_tag ("html", "body"));
+        1, 10, E (`Misnested_tag ("body", "body"));
+        1, 16, S  `End_element;
+        1, 16, S (start_element "p");
+        1, 26, E (`Bad_document ("content after body"));
+        1, 26, S (start_element "br");
+        1, 26, S  `End_element;
+        1, 30, S  `End_element;
+        1, 30, S (start_element "p");
+        1, 33, S  `End_element;
+        1, 33, S  `End_element;
+        1, 33, S  `End_element]
+  );
+
   ("html.parser.foreign" >:: fun _ ->
     expect "<body><svg><g/></svg></body>"
       [ 1,  1, S (start_element "html");
@@ -483,7 +504,7 @@ let tests = [
         1, 12, S (`Start_element ((svg_ns, "g"), []));
         1, 12, S  `End_element;
         1, 16, S  `End_element;
-        1, 22, S  `End_element;
+        1, 29, S  `End_element;
         1, 29, S  `End_element]);
 
   ("html.parser.reconstruct-active-formatting-elements" >:: fun _ ->
@@ -807,7 +828,7 @@ let tests = [
   ("html.parser.body.fragment" >:: fun _ ->
     expect ~context:None "<body></body>"
       [ 1,  1, S (start_element "body");
-        1,  7, S  `End_element]);
+        1, 14, S  `End_element]);
 
   ("html.parser.body.content-truncated" >:: fun _ ->
     expect ~context:None "<p></body></html>foo"
@@ -1135,8 +1156,8 @@ let tests = [
         1, 10, E (`Misnested_tag ("frameset", "body"));
         1, 20, S  `End_element;
         1, 20, S (start_element "p");
-        1, 23, S  `End_element;
-        1, 23, S  `End_element];
+        1, 30, S  `End_element;
+        1, 30, S  `End_element];
 
     expect ~context:None "<p><frameset><p>"
       [ 1,  1, S (start_element "p");

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -40,7 +40,7 @@ let tests = [
         1, 28, S  `End_element;
         1, 35, S (start_element "body");
         1, 41, S  `End_element;
-        1, 48, S  `End_element];
+        1, 55, S  `End_element];
 
     expect ~prefix:true " <!--foo--> <!DOCTYPE html>"
       [ 1,  2, S (`Comment "foo");
@@ -72,8 +72,8 @@ let tests = [
         1, 22, S (start_element "head");
         1, 22, S  `End_element;
         1, 22, S (start_element "body");
-        1, 22, S  `End_element;
-        1, 22, S  `End_element];
+        1, 29, S  `End_element;
+        1, 29, S  `End_element];
 
     expect "<!DOCTYPE html><head></head>"
       [ 1,  1, S  doctype;
@@ -437,8 +437,8 @@ let tests = [
         1,  1, S (start_element "head");
         1,  1, S  `End_element;
         1,  1, S (start_element "body");
-        1,  7, S  `End_element;
-        1,  7, S  `End_element]);
+        1, 14, S  `End_element;
+        1, 14, S  `End_element]);
 
   ("html.parser.junk-in-body" >:: fun _ ->
     expect "<body>\x00<!DOCTYPE html><html><meta><body></body>"
@@ -454,6 +454,24 @@ let tests = [
         1, 35, E (`Misnested_tag ("body", "body"));
         1, 41, S  `End_element;
         1, 48, S  `End_element]);
+
+  ("html.parser.nested-html-in-body" >:: fun _ ->
+    expect "<div><html></html>foo</div><div>bar</div>"
+      [ 1,  1, S (start_element "html");
+        1,  1, S (start_element "head");
+        1,  1, S  `End_element;
+        1,  1, S (start_element "body");
+        1,  1, S (start_element "div");
+        1,  6, E (`Misnested_tag ("html", "body"));
+        1,  1, E (`Unmatched_start_tag "div");
+        1, 19, E (`Bad_content "html");
+        1, 19, S (`Text ["foo"]);
+        1, 22, S  `End_element;
+        1, 28, S (start_element "div");
+        1, 33, S (`Text ["bar"]);
+        1, 36, S  `End_element;
+        1, 42, S  `End_element;
+        1, 42, S  `End_element]);
 
   ("html.parser.foreign" >:: fun _ ->
     expect "<body><svg><g/></svg></body>"
@@ -546,8 +564,8 @@ let tests = [
         1,  7, S (start_element "head");
         1,  7, S  `End_element;
         1,  7, S (start_element "body");
-        1,  7, S  `End_element;
-        1,  7, S  `End_element]);
+        1, 14, S  `End_element;
+        1, 14, S  `End_element]);
 
   ("html.parser.foreign-context" >:: fun _ ->
     expect ~context:None "<g/>"


### PR DESCRIPTION
@TheCBaH, thanks for reporting #28, discussion, and links to parse5 code. After looking at the parse5 code, I realized that it's actually pretty close to the HTML5 spec. Looking more closely at the spec, it turned out that the problem Markup.ml is having in #28 is that it is *not following the spec closely enough.* So, I propose to make it more compliant in this PR, rather than merging #29 :)

The reason for the deviation is that the spec specifies a parser that constructs an in-memory document tree. By contract, Markup.ml is a streaming parser. One of the things it does is try to guess when elements are closed, so it can emit the `` `End_element `` signal with proper location.

The problem in #28 was caused by Markup.ml being too eager with this guessing. It was closing the `<body>` and `<html>` elements too early, and closing all their children, causing the observed behavior.

See the included test for the new behavior. I basically took it from the AST you linked to in #28.

Some other notes from the commit message:

```
An unfortunate side effect of this change is that the parser now always
ignores </html> tags, because the point where it would legitimately
close an <html> element cannot be distinguished from an error. That
would require adding more state or callback parameters, which was not
done in this commmit.

As a result, <html> elements are only closed implicitly by the end of
input. As a further result, the location of the closing </html> tag is
always reported as the location of the end of the input. In other words,
if there is a legitimate </html> tag, its location is not accurately
reported.
```

Fixes #28.