### PR TITLE
Whitespace-aware pretty-printer

### DIFF
--- a/src/utility.ml
+++ b/src/utility.ml
@@ -318,11 +318,16 @@ let pretty_print signals =
           [`Text [indent (indentation - 1)]; signal; `Text ["\n"]]
           (flow (indentation - 1)) throw e k
 
-      | _ ->
+      | `Start_element _ | `Text _ ->
         push signals signal;
         list
           [`Text [indent indentation]]
           (phrasing indentation 0) throw e k
+
+      | _ ->
+        list
+          [signal]
+          (flow indentation) throw e k
     end
 
   and phrasing indentation phrasing_nesting_level throw e k =

--- a/test/dune
+++ b/test/dune
@@ -6,4 +6,4 @@
 (alias
  (name runtest)
  (package markup)
- (action (run %{exe:test.exe})))
+ (action (run %{exe:test.exe} -runner sequential)))

--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -69,8 +69,8 @@ let tests = [
     |> write_xml
     |> to_string
     |> assert_equal
-      ("<root>\n  foo\n  <nested>\n    bar\n  </nested>\n" ^
-       "  <nested>\n    baz\n  </nested>\n</root>\n"));
+      ("<root>\n foo\n <nested>\n  bar\n </nested>\n" ^
+       " <nested>\n  baz\n </nested>\n</root>\n"));
 
   ("integration.locations" >:: fun _ ->
     let parser = "<root>foo</root>" |> string |> parse_xml in

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -219,7 +219,6 @@ let tests = [
       start_element "div";
       `Text ["\n"; " "];
       start_element "p";
-      `Text ["\n"; " "];
       `End_element;
       `Text ["\n"];
       `End_element;

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -8,7 +8,7 @@ open Markup__Common
 open Markup
 module Kstream = Markup__Kstream
 
-let start_element name = `Start_element (("", name), [])
+let start_element name = `Start_element ((Markup.Ns.html, name), [])
 
 let ok = wrong_k "failed"
 
@@ -76,8 +76,10 @@ let tests = [
       Element ("p", [Text "foo"; Element ("em", [Text "bar"]); Text "baz"]) in
     dom
     |> from_tree (function
-      | Element (name, children) -> `Element (("", name), [], children)
-      | Text s -> `Text s)
+      | Element (name, children) ->
+        `Element ((Markup.Ns.html, name), [], children)
+      | Text s ->
+        `Text s)
     |> to_list
     |> assert_equal [
       start_element "p";
@@ -101,25 +103,36 @@ let tests = [
     |> assert_equal "foobarbaz");
 
   ("utility.trim" >:: fun _ ->
-    [`Text ["\n"];
-     start_element "a";
-     `Text ["\n  content\n  "];
+    [start_element "div";
+     `Text ["\n "];
+     start_element "p";
+     `Text ["\n  "];
+     start_element "em";
+     `Text ["foo"];
      `End_element;
-     `Text ["\n\n"];
-     start_element "a";
-     `Text ["\n"; "\n"];
+     `Text [" bar\n "];
      `End_element;
-     `Text [" "; "\n"; " more content "; "\n"; "\n"]]
+     `Text ["\n "];
+     start_element "pre";
+     `Text ["\n baz \n "];
+     `End_element;
+     `Text ["\n"];
+     `End_element]
     |> of_list
     |> trim
     |> to_list
-    |> assert_equal [
-      start_element "a";
-      `Text ["content"];
-      `End_element;
-      start_element "a";
-      `End_element;
-      `Text ["more content"]]);
+    |> assert_equal
+    [start_element "div";
+     start_element "p";
+     start_element "em";
+     `Text ["foo"];
+     `End_element;
+     `Text [" bar"];
+     `End_element;
+     start_element "pre";
+     `Text ["\n baz \n "];
+     `End_element;
+     `End_element]);
 
   ("utility.normalize_text" >:: fun _ ->
     [`Text [""];
@@ -139,25 +152,35 @@ let tests = [
       `Text ["foo"; "bar"; "baz"; "quux"]]);
 
   ("utility.pretty_print" >:: fun _ ->
-    [`Text ["foo"];
-     start_element "a";
-     `Text [" bar "];
-     `Text [" baz "];
-     start_element "b";
-     `Text ["quux"];
+    [start_element "div";
+     start_element "p";
+     start_element "em";
+     `Text ["foo"];
+     `End_element;
+     `Text ["bar"];
+     `End_element;
+     start_element "pre";
+     `Text ["\n baz \n "];
      `End_element;
      `End_element]
     |> of_list
     |> pretty_print
     |> to_list
     |> assert_equal [
-      `Text ["foo"; "\n"];
-      start_element "a";
-      `Text ["\n"; "  "; "bar "; " baz"; "\n"; "  "];
-      start_element "b";
-      `Text ["\n"; "    "; "quux"; "\n"; "  "];
-      `End_element;
-      `Text ["\n"];
-      `End_element;
-      `Text ["\n"]])
+     start_element "div";
+     `Text ["\n"; " "];
+     start_element "p";
+     `Text ["\n"; "  "];
+     start_element "em";
+     `Text ["foo"];
+     `End_element;
+     `Text ["bar"; "\n"; " "];
+     `End_element;
+     `Text ["\n"; " "];
+     start_element "pre";
+     `Text ["\n baz \n "];
+     `End_element;
+     `Text ["\n"];
+     `End_element;
+     `Text ["\n"]]);
 ]

--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -8,6 +8,14 @@ open Markup__Common
 open Markup
 module Kstream = Markup__Kstream
 
+let doctype =
+  `Doctype
+    {Markup.doctype_name = Some "html";
+     public_identifier   = None;
+     system_identifier   = None;
+     raw_text            = None;
+     force_quirks        = false}
+
 let start_element name = `Start_element ((Markup.Ns.html, name), [])
 
 let ok = wrong_k "failed"
@@ -134,6 +142,19 @@ let tests = [
      `End_element;
      `End_element]);
 
+  ("utility.trim.doctype" >:: fun _ ->
+    [doctype;
+     `Text ["\n"];
+     start_element "div";
+     `End_element]
+    |> of_list
+    |> trim
+    |> to_list
+    |> assert_equal [
+      doctype;
+      start_element "div";
+      `End_element]);
+
   ("utility.normalize_text" >:: fun _ ->
     [`Text [""];
      start_element "a";
@@ -183,4 +204,24 @@ let tests = [
      `Text ["\n"];
      `End_element;
      `Text ["\n"]]);
+
+  ("utility.pretty_print.doctype" >:: fun _ ->
+    [doctype;
+     start_element "div";
+     start_element "p";
+     `End_element;
+     `End_element]
+    |> of_list
+    |> pretty_print
+    |> to_list
+    |> assert_equal [
+      doctype;
+      start_element "div";
+      `Text ["\n"; " "];
+      start_element "p";
+      `Text ["\n"; " "];
+      `End_element;
+      `Text ["\n"];
+      `End_element;
+      `Text ["\n"]]);
 ]


### PR DESCRIPTION
This changes `Markup.trim` and `Markup.pretty_print` to respect whitespace in HTML phrasing ("inline") content. So, applying `Markup.trim` to

```html
<div>
 <p>
  <em>foo</em> bar
 </p>
</div>
```

produces

```html
<div><p><em>foo</em> bar</p></div>
```

and, notionally the inverse, applying `Markup.pretty_print` to

```html
<div><p><em>foo</em>bar</p></div>
```

produces

```html
<div>
 <p>
  <em>foo</em>bar
 </p>
</div>
```

The important thing is that `Markup.trim` did not remove whitespace around `</em>`, and `Markup.pretty_print` did not introduce whitespace around `</em>`. This preserves the word breaks in the HTML.

I went for the simplest possible pretty-printer that is correct with respect to word breaks. It doesn't try to limit the line length or do anything else that could be considered fancy. It just indents the flow ("block") content, and passes phrasing ("inline", word) content straight through. This can result in long lines, but we can adjust that later with more elaborate implementations. The point is that from now, no matter how simple or fancy, or how nice or ugy the output looks, `Markup.pretty_print` should be correct and safe to use on HTML, modulo bugs :)

As an aside, pretty-printing HTML is not correct in the general case, because the significance of whitespace in each element is up to CSS, and that is outside HTML. Each pretty-printer basically has to make a guess that the input is valid, and that the CSS uses the default interpretations of whitespace for each kind of element.

cc @ostera, @Drup

Resolves #35.
