### PR TITLE
write_html: added ?escape_attribute and ?escape_text arguments.

### DIFF
--- a/src/html_writer.ml
+++ b/src/html_writer.ml
@@ -49,7 +49,7 @@ open Kstream
 let literal_text_elements =
   ["style"; "script"; "xmp"; "iframe"; "noembed"; "noframes"; "plaintext"]
 
-let write signals =
+let write ?(escape_attribute=escape_attribute) ?(escape_text=escape_text) signals =
   let open_elements = ref [] in
 
   let in_literal_text_element () =

--- a/src/html_writer.mli
+++ b/src/html_writer.mli
@@ -3,4 +3,7 @@
 
 open Common
 
-val write : [< signal ] Kstream.t -> string Kstream.t
+val write :
+  ?escape_attribute:(string -> string) ->
+  ?escape_text:(string -> string) ->
+  [< signal ] Kstream.t -> string Kstream.t

--- a/src/markup.ml
+++ b/src/markup.ml
@@ -151,9 +151,9 @@ struct
     Kstream.construct constructor
     |> stream_to_parser
 
-  let write_html signals =
+  let write_html ?escape_attribute ?escape_text signals =
     signals
-    |> Html_writer.write
+    |> Html_writer.write ?escape_attribute ?escape_text
     |> Utility.strings_to_bytes
 end
 
@@ -222,7 +222,10 @@ sig
     ?context:[< `Document | `Fragment of string ] ->
     (char, _) stream -> async parser
 
-  val write_html : ([< signal ], _) stream -> (char, async) stream
+  val write_html :
+  ?escape_attribute:(string -> string) ->
+  ?escape_text:(string -> string) ->
+  ([< signal ], _) stream -> (char, async) stream
 
   val fn : (unit -> char option io) -> (char, async) stream
 
@@ -296,8 +299,8 @@ struct
 
     Cps.parse_html (wrap_report report) ?encoding context source
 
-  let write_html signals =
-    Cps.write_html signals
+  let write_html ?escape_attribute ?escape_text signals =
+    Cps.write_html ?escape_attribute ?escape_text signals
 
   let to_string bytes = Stream_io.to_string bytes |> IO.of_cps
   let to_buffer bytes = Stream_io.to_buffer bytes |> IO.of_cps

--- a/src/markup.mli
+++ b/src/markup.mli
@@ -412,8 +412,14 @@ foo</bar>
 
  *)
 
-val write_html : ([< signal ], 's) stream -> (char, 's) stream
-(** Similar to {!write_xml}, but emits HTML5 instead of XML. *)
+val write_html :
+  ?escape_attribute:(string -> string) ->
+  ?escape_text:(string -> string) ->
+  ([< signal ], 's) stream -> (char, 's) stream
+(** Similar to {!write_xml}, but emits HTML5 instead of XML.
+    If [~escape_attribute] and/or [~escape_text] are provided,
+    they are used instead of default escaping functions.
+*)
 
 
 
@@ -846,7 +852,10 @@ sig
     ?context:[< `Document | `Fragment of string ] ->
     (char, _) stream -> async parser
 
-  val write_html : ([< signal ], _) stream -> (char, async) stream
+  val write_html :
+    ?escape_attribute:(string -> string) ->
+    ?escape_text:(string -> string) ->
+    ([< signal ], _) stream -> (char, async) stream
 
   (** {2 I/O} *)
 


### PR DESCRIPTION
Hi!

I would like to plug my own escaping function to Markup.ml (this one, https://github.com/tategakibunko/jingoo/blob/master/src/jg_utils.ml#L148). 

What about adding these two arguments?