### PR TITLE
Stop tokenizer using start chars for attributes

### DIFF
--- a/src/xml_tokenizer.ml
+++ b/src/xml_tokenizer.ml
@@ -232,7 +232,7 @@ let tokenize report resolve_reference (input, get_location) =
           consume_whitespace equals_state)
 
         | l, c ->
-          report_if (not @@ is_name_start_char c) l (fun () ->
+          report_if (not @@ is_name_char c) l (fun () ->
             `Bad_token (char c, "attribute", "invalid name character"))
             !throw (fun () ->
           add_utf_8 name_buffer c;

--- a/test/test_xml_tokenizer.ml
+++ b/test/test_xml_tokenizer.ml
@@ -591,6 +591,16 @@ let tests = [
         1,  1, S (`Start (tag "foo" ["b!ar", ""]));
         1, 14, S  `EOF]);
 
+  ("xml.tokenizer.good-attribute-name" >:: fun _ ->
+    expect "<foo -bar=''>"
+      [ 1,  6, E (`Bad_token ("-", "attribute", "invalid start character"));
+        1,  1, S (`Start (tag "foo" ["-bar", ""]));
+        1, 14, S  `EOF];
+
+    expect "<foo b-ar=''>"
+      [ 1,  1, S (`Start (tag "foo" ["b-ar", ""]));
+        1, 14, S  `EOF]);
+
   ("xml.tokenizer.bad-attribute-whitespace" >:: fun _ ->
     expect "<foo bar  =  'baz'>"
       [ 1,  9, E (`Bad_token (" ", "attribute", "whitespace not allowed here"));


### PR DESCRIPTION
This is a change to stop legitimate name characters in attribute names
causing errors, e.g. '-' should be allowed.