### PR TITLE
Fixed Html_tokenizer.match_named (some chars was dropped).

### DIFF
--- a/src/html_tokenizer.ml
+++ b/src/html_tokenizer.ml
@@ -381,7 +381,7 @@ let tokenize report (input, get_location) =
                 match_named (Some (w, m)) (v::(replace @ matched)) [] trie text
               | Trie.Yes m ->
                 let w = Buffer.contents text in
-                finish (Some (w, m)) (v::matched) [])
+                finish (Some (w, m)) (v::(replace @ matched)) [])
         in
         match_named
           None [] [] (Lazy.force named_entity_trie) (Buffer.create 16))

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -282,6 +282,43 @@ let tests = [
         1, 27, S  `End_element;
         1, 27, S  `End_element]);
 
+  ("html.parser.links" >:: fun _ ->
+    expect
+      {|<a href="foo.com?bar=on&acte=123">foo</a>|}
+      [ 1,  1, S (start_element "html");
+        1,  1, S (start_element "head");
+        1,  1, S  `End_element;
+        1,  1, S (start_element "body");
+        1, 1, S (`Start_element ((html_ns, "a"), [(("", "href"), "foo.com?bar=on&acte=123")]));
+        1,  35, S (`Text ["foo"]);
+        1,  38, S  `End_element;
+        1, 42, S  `End_element;
+        1, 42, S  `End_element];
+
+    expect
+      {|<a href="foo.com?bar=on&image=on">foo</a>|}
+      [ 1,  1, S (start_element "html");
+        1,  1, S (start_element "head");
+        1,  1, S  `End_element;
+        1,  1, S (start_element "body");
+        1, 1, S (`Start_element ((html_ns, "a"), [(("", "href"), "foo.com?bar=on&image=on")]));
+        1,  35, S (`Text ["foo"]);
+        1,  38, S  `End_element;
+        1, 42, S  `End_element;
+        1, 42, S  `End_element];
+
+    expect
+      {|<a href="foo.com?bar=on&image;">foo</a>|}
+      [ 1,  1, S (start_element "html");
+        1,  1, S (start_element "head");
+        1,  1, S  `End_element;
+        1,  1, S (start_element "body");
+        1, 1, S (`Start_element ((html_ns, "a"), [(("", "href"), "foo.com?bar=onℑ")]));
+        1,  33, S (`Text ["foo"]);
+        1,  36, S  `End_element;
+        1, 40, S  `End_element;
+        1, 40, S  `End_element]);
+
   ("html.parser.headings" >:: fun _ ->
     expect "<p><h1><h2>foo</h2>"
       [ 1,  1, S (start_element "html");

--- a/test/test_html_tokenizer.ml
+++ b/test/test_html_tokenizer.ml
@@ -884,6 +884,12 @@ let tests = [
         1,  1, S (`Start (tag "foo" ["bar", "&lt="]));
         1, 17, S  `EOF];
 
+    expect "<foo bar='&image='>"
+      [ 1, 11, E (`Bad_token ("&image=", "attribute",
+                              "unterminated entity reference followed by '='"));
+        1,  1, S (`Start (tag "foo" ["bar", "&image="]));
+        1, 20, S  `EOF];
+
     expect "<foo bar=&amp;>"
       [ 1,  1, S (`Start (tag "foo" ["bar", "&"]));
         1, 16, S  `EOF];


### PR DESCRIPTION
For some obscure reason (I did not look at the code yet), the parser fail with this simple input.

```
Error: markup.ml:218:html.parser.links (in the log).

File "test/support/test_support.ml", line 70, characters 1-1:
Error: markup.ml:218:html.parser.links (in the code).

<a href="foo.com?bar=on&image=on">foo</a>
got "line 1, column 1: <http://www.w3.org/1999/xhtml:a href="foo.com?bar=on&e=on">"
expected "line 1, column 1: <http://www.w3.org/1999/xhtml:a href="foo.com?bar=on&image=on">"
```

```
Error: markup.ml:195:html.tokenizer.reference-in-attribute (in the code).

<foo bar='&image='>
got "line 1, column 1: <foo bar="&e=">"
expected "line 1, column 1: <foo bar="&image=">"
```