### PR TITLE
[docs] fix tree example

### DIFF
--- a/src/markup.mli
+++ b/src/markup.mli
@@ -569,7 +569,7 @@ type my_dom = Text of string | Element of name * my_dom list
 |> signals
 |> tree
   ~text:(fun ss -> Text (String.concat "" ss))
-  ~element:(fun (name, _) children -> Element (name, children))
+  ~element:(fun (_ns, name) _attrs children -> Element (name, children))
 ]}
 
     results in the structure


### PR DESCRIPTION
Hopefully I've understood the types correctly. It should compile at least, but the names are guessed.

On another note, it's also unclear to me why `tree` returns an `option`. In which cases will it `None`. I would guess it's if an end element is either missing, or not aligned with an accompanying start element. But is that all?