### PR TITLE
[WIP] Bugfix: `trim` does not remove whitespace-only text signals in certain cases

### DIFF
--- a/test/test_utility.ml
+++ b/test/test_utility.ml
@@ -141,6 +141,42 @@ let tests = [
      `Text ["\n baz \n "];
      `End_element;
      `End_element]);
+  
+  ("utility.trim whitespace between start and end elements" >:: fun _ ->
+    [start_element "div";
+     start_element "em";
+     `Text ["\n"];
+     `End_element;
+     `Text ["\n"];
+     `End_element]
+    |> of_list
+    |> trim
+    |> to_list
+    |> assert_equal
+    [start_element "div";
+     start_element "em";
+     (*`Text ["\n"];*)
+     `End_element;
+     `End_element]);
+
+  ("utility.trim whitespace comment" >:: fun _ ->
+    [start_element "div";
+     start_element "em";
+     `End_element;
+     `Text ["\n"];
+     `Comment "a comment";
+     `Text ["\n"];
+     `End_element]
+    |> of_list
+    |> trim
+    |> to_list
+    |> assert_equal
+    [start_element "div";
+     start_element "em";
+     `End_element;
+     (*`Text ["\n"];*)
+     `Comment "a comment";
+     `End_element]);
 
   ("utility.trim.doctype" >:: fun _ ->
     [doctype;


### PR DESCRIPTION
I've added a couple of failing tests for this, but struggle to understand the logic of `trim`, and why it needs to be so complex at all. Why can it not just filter out all whitespace-only `` `Text`` signals.

I'll try to prod at it a bit to see if I can figure it out, but any hints you might have would be appreciated.