### PR TITLE
Report attributes with `Misnested_tag

### DIFF
--- a/src/error.ml
+++ b/src/error.ml
@@ -11,7 +11,7 @@ type t =
   | `Unmatched_start_tag of string
   | `Unmatched_end_tag of string
   | `Bad_namespace of string
-  | `Misnested_tag of string * string
+  | `Misnested_tag of string * string * (string * string) list
   | `Bad_content of string ]
 
 let explode_string s =
@@ -59,7 +59,7 @@ let to_string ?location error =
     | `Bad_namespace s ->
       fmt "unknown namespace '%s'" s
 
-    | `Misnested_tag (s, in_) ->
+    | `Misnested_tag (s, in_, _attributes) ->
       fmt "misnested tag: '%s' in '%s'" s in_
 
     | `Bad_content s ->

--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1025,6 +1025,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
   let report_if = Error.report_if report in
   let unmatched_end_tag l name k =
     report l (`Unmatched_end_tag name) !throw k in
+  let misnested_tag l t context_name k =
+    report l (`Misnested_tag (t.name, context_name, t.Token_tag.attributes)) !throw k in
 
   let open_elements = Stack.create () in
   let active_formatting_elements = Active.create () in
@@ -1512,8 +1514,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
         close_element_with_implied "template" l (fun () -> reset_mode () ())
       end
 
-    | l, `Start {name = "head"} ->
-      report l (`Misnested_tag ("head", "head")) !throw mode
+    | l, `Start ({name = "head"} as t) ->
+      misnested_tag l t "head" mode
 
     | l, `End {name} when not @@ list_mem_string name ["body"; "html"; "br"] ->
       report l (`Unmatched_end_tag name) !throw mode
@@ -1542,9 +1544,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           "style"} as v ->
         in_head_mode_rules in_head_noscript_mode v
 
-      | l, `Start {name = "head" | "noscript" as name} ->
-        report l (`Misnested_tag (name, "noscript")) !throw
-          in_head_noscript_mode
+      | l, `Start ({name = "head" | "noscript"} as t) ->
+        misnested_tag l t "noscript" in_head_noscript_mode
 
       | l, `End {name} when name <> "br" ->
         report l (`Unmatched_end_tag name) !throw in_head_noscript_mode
@@ -1579,10 +1580,10 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       | l, `Start ({name = "frameset"} as t) ->
         push_and_emit l t in_frameset_mode
 
-      | l, `Start {name =
+      | l, `Start ({name =
           "base" | "basefont" | "bgsound" | "link" | "meta" | "noframes" |
-          "script" | "style" | "template" | "title" as name} as v ->
-        report l (`Misnested_tag (name, "html")) !throw (fun () ->
+          "script" | "style" | "template" | "title"} as t) as v ->
+        misnested_tag l t "html" (fun () ->
         in_head_mode_rules after_head_mode v)
 
       | _, `End {name = "template"} as v ->
@@ -1635,8 +1636,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
     | l, `Doctype _ ->
       report l (`Bad_document "doctype should be first") !throw mode
 
-    | l, `Start {name = "html"} ->
-      report l (`Misnested_tag ("html", context_name)) !throw mode
+    | l, `Start ({name = "html"} as t) ->
+      misnested_tag l t context_name mode
 
     | _, `Start {name =
         "base" | "basefont" | "bgsound" | "link" | "meta" | "noframes" |
@@ -1644,11 +1645,11 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
     | _, `End {name = "template"} as v ->
       in_head_mode_rules mode v
 
-    | l, `Start {name = "body"} ->
-      report l (`Misnested_tag ("body", context_name)) !throw mode
+    | l, `Start ({name = "body"} as t) ->
+      misnested_tag l t context_name mode
 
     | l, `Start ({name = "frameset"} as t) ->
-      report l (`Misnested_tag ("frameset", context_name)) !throw (fun () ->
+      misnested_tag l t context_name (fun () ->
       match !open_elements with
       | [_] -> mode ()
       | _ ->
@@ -1706,13 +1707,13 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       push_and_emit l t mode)
 
     | l, `Start ({name =
-        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" as name} as t) ->
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6"} as t) ->
       close_current_p_element l (fun () ->
       (fun mode' ->
         match Stack.current_element open_elements with
         | Some {element_name = `HTML,
             ("h1" | "h2" | "h3" | "h4" | "h5" | "h6" as name')} ->
-          report l (`Misnested_tag (name, name')) !throw (fun () ->
+          misnested_tag l t name' (fun () ->
           pop l mode')
         | _ -> mode' ()) (fun () ->
       push_and_emit l t mode))
@@ -1730,7 +1731,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
     | l, `Start ({name = "form"} as t) ->
       if !form_element_pointer <> None &&
          not @@ Stack.has open_elements "template" then
-        report l (`Misnested_tag ("form", "form")) !throw mode
+        misnested_tag l t "form" mode
       else begin
         close_current_p_element l (fun () ->
         let in_template = Stack.has open_elements "template" in
@@ -1757,7 +1758,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
     | l, `Start ({name = "button"} as t) ->
       (fun mode' ->
         if Stack.in_scope open_elements "button" then
-          report l (`Misnested_tag ("button", "button")) !throw (fun () ->
+          misnested_tag l t "button" (fun () ->
           close_element_with_implied "button" l mode')
         else mode' ())
       (fun () ->
@@ -1843,7 +1844,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
         match Active.has_before_marker active_formatting_elements "a" with
         | None -> k ()
         | Some existing ->
-          report l (`Misnested_tag ("a", "a")) !throw (fun () ->
+          misnested_tag l t "a" (fun () ->
           adoption_agency_algorithm l "a" (fun () ->
           Stack.remove open_elements existing;
           Active.remove active_formatting_elements existing;
@@ -1866,7 +1867,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       (fun k ->
         if not @@ Stack.in_scope open_elements "nobr" then k ()
         else
-          report l (`Misnested_tag ("nobr", "nobr")) !throw (fun () ->
+          misnested_tag l t "nobr" (fun () ->
           adoption_agency_algorithm l "nobr" (fun () ->
           reconstruct_active_formatting_elements k)))
       (fun () -> push_and_emit ~formatting:true l t mode))
@@ -1968,14 +1969,14 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
         reconstruct_active_formatting_elements (fun () ->
         push_and_emit l t mode))
 
-    | l, `Start ({name = "rb" | "rp" | "rtc" as name} as t) ->
+    | l, `Start ({name = "rb" | "rp" | "rtc"} as t) ->
       (fun mode' ->
         if Stack.in_scope open_elements "ruby" then
           pop_implied l (fun () ->
           if Stack.current_element_is open_elements ["ruby"] then
             mode' ()
           else
-            report l (`Misnested_tag (name, context_name)) !throw mode'))
+            misnested_tag l t context_name mode'))
       (fun () ->
         push_and_emit l t mode)
 
@@ -1986,7 +1987,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           if Stack.current_element_is open_elements ["ruby"; "rtc"] then
             mode' ()
           else
-            report l (`Misnested_tag ("rt", context_name)) !throw mode'))
+            misnested_tag l t context_name mode'))
       (fun () ->
         push_and_emit l t mode)
 
@@ -2002,10 +2003,10 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       if t.self_closing then pop l mode
       else mode ()))
 
-    | l, `Start {name =
+    | l, `Start ({name =
         "caption" | "col" | "colgroup" | "frame" | "head" | "tbody" | "td" |
-        "tfoot" | "th" | "thead" | "tr" as name} ->
-      report l (`Misnested_tag (name, context_name)) !throw mode
+        "tfoot" | "th" | "thead" | "tr"} as t) ->
+      misnested_tag l t context_name mode
 
     | l, `Start t ->
       reconstruct_active_formatting_elements (fun () ->
@@ -2126,8 +2127,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       push tokens v;
       push_implicit l "tbody" in_table_body_mode)
 
-    | l, `Start {name = "table"} as v ->
-      report l (`Misnested_tag ("table", "table")) !throw (fun () ->
+    | l, `Start ({name = "table"} as t) as v ->
+      misnested_tag l t "table" (fun () ->
       if not @@ Stack.has open_elements "table" then mode ()
       else begin
         push tokens v;
@@ -2150,12 +2151,12 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       in_head_mode_rules mode v
 
     | l, `Start ({name = "input"} as t) when Element.is_not_hidden t ->
-      report l (`Misnested_tag ("input", "table")) !throw (fun () ->
+      misnested_tag l t "table" (fun () ->
       push_and_emit ~acknowledge:true l t (fun () ->
       pop l mode))
 
     | l, `Start ({name = "form"} as t) ->
-      report l (`Misnested_tag ("form", "table")) !throw (fun () ->
+      misnested_tag l t "table" (fun () ->
       push_and_emit l t (fun () ->
       pop l mode))
 
@@ -2205,10 +2206,10 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           close_element_with_implied "caption" l in_table_mode
         end
 
-      | l, `Start {name =
+      | l, `Start ({name =
           "caption" | "col" | "colgroup" | "tbody" | "td" | "tfoot" | "th" |
-          "thead" | "tr" as name} as v ->
-        report l (`Misnested_tag (name, "caption")) !throw (fun () ->
+          "thead" | "tr"} as t) as v ->
+        misnested_tag l t "caption" (fun () ->
         if not @@ Stack.in_table_scope open_elements "caption" then
           in_caption_mode ()
         else begin
@@ -2292,8 +2293,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
         pop_to_table_body_context l (fun () ->
         push_and_emit l t in_row_mode)
 
-      | l, `Start {name = ("th" | "td") as name} as v ->
-        report l (`Misnested_tag (name, "table")) !throw (fun () ->
+      | l, `Start ({name = "th" | "td"} as t) as v ->
+        misnested_tag l t "table" (fun () ->
         pop_to_table_body_context l (fun () ->
         push tokens v;
         push_implicit l "tr" in_row_mode))
@@ -2305,12 +2306,12 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           pop_to_table_body_context l (fun () ->
           pop l in_table_mode)
 
-      | l, `Start {name =
-          "caption" | "col" | "colgroup" | "tbody" | "tfoot" | "thead"
-          as name} as v ->
+      | l, `Start ({name =
+          "caption" | "col" | "colgroup" | "tbody" | "tfoot" | "thead"} as t)
+          as v ->
         if not @@ Stack.one_in_table_scope open_elements
             ["tbody"; "thead"; "tfoot"] then
-          report l (`Misnested_tag (name, "table")) !throw in_table_body_mode
+          misnested_tag l t "table" in_table_body_mode
         else begin
           push tokens v;
           pop_to_table_body_context l (fun () ->
@@ -2357,8 +2358,8 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       | l, `End {name = "table"} as v ->
         if not @@ Stack.in_table_scope open_elements "tr" then
           match snd v with
-          | `Start {name} ->
-            report l (`Misnested_tag (name, "tr")) !throw in_row_mode
+          | `Start t ->
+            misnested_tag l t "tr" in_row_mode
           | `End {name} ->
             report l (`Unmatched_end_tag name) !throw in_row_mode
         else
@@ -2396,11 +2397,11 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           Active.clear_until_marker active_formatting_elements;
           in_row_mode ())
 
-      | l, `Start {name =
+      | l, `Start ({name =
           "caption" | "col" | "colgroup" | "tbody" | "td" | "tfoot" | "th" |
-          "thead" | "tr" as name} as v ->
+          "thead" | "tr"} as t) as v ->
         if not @@ Stack.one_in_table_scope open_elements ["td"; "th"] then
-          report l (`Misnested_tag (name, "td/th")) !throw in_cell_mode
+          misnested_tag l t "td/th" in_cell_mode
         else
           close_cell l (fun () ->
           Active.clear_until_marker active_formatting_elements;
@@ -2489,12 +2490,12 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       else
         close_element l "select" (fun () -> reset_mode () ())
 
-    | l, `Start {name = "select"} ->
-      report l (`Misnested_tag ("select", "select")) !throw (fun () ->
+    | l, `Start ({name = "select"} as t) ->
+      misnested_tag l t "select" (fun () ->
       close_element l "select" (fun () -> reset_mode () ()))
 
-    | l, `Start {name = "input" | "keygen" | "textarea" as name} as v ->
-      report l (`Misnested_tag (name, "select")) !throw (fun () ->
+    | l, `Start ({name = "input" | "keygen" | "textarea"} as t) as v ->
+      misnested_tag l t "select" (fun () ->
       if not @@ Stack.in_select_scope open_elements "select" then
         mode ()
       else begin
@@ -2515,10 +2516,10 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
   (* 8.2.5.4.17. *)
   and in_select_in_table_mode () =
     dispatch tokens begin function
-      | l, `Start {name =
+      | l, `Start ({name =
           "caption" | "table" | "tbody" | "tfoot" | "thead" | "tr" | "td" |
-          "th" as name} as v ->
-        report l (`Misnested_tag (name, "table")) !throw (fun () ->
+          "th"} as t) as v ->
+        misnested_tag l t "table" (fun () ->
         push tokens v;
         close_element l "select" (fun () -> reset_mode () ()))
 
@@ -2793,7 +2794,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       if name = "font" && not @@ is_html_font_tag t then
         foreign_start_tag mode l t
       else
-        report l (`Misnested_tag (name, "xml tag")) !throw (fun () ->
+        misnested_tag l t "xml tag" (fun () ->
         push tokens v;
         pop l (fun () ->
         pop_until (function

--- a/src/markup.mli
+++ b/src/markup.mli
@@ -129,7 +129,7 @@ sig
     | `Unmatched_start_tag of string
     | `Unmatched_end_tag of string
     | `Bad_namespace of string
-    | `Misnested_tag of string * string
+    | `Misnested_tag of string * string * (string * string) list
     | `Bad_content of string ]
   (** Errors reported by the parsers. A few of these are also used by the
       writers.
@@ -163,10 +163,10 @@ sig
         resolved to a namespace, and by the writers when the namespace [s] can't
         be resolved to a prefix (or the default namespace).
 
-      - [`Misnested_tag (what, where)] is reported by the HTML parser when a tag
-        appears where it is not allowed. For example, if the input has a
-        [<body>] tag inside a [<p>] tag, the parser will report
-        [`Misnested_tag ("body", "p")].
+      - [`Misnested_tag (what, where, attributes)] is reported by the HTML
+        parser when a tag appears where it is not allowed. For example, if the
+        input has a [<body class="">] tag inside a [<p>] tag, the parser will
+        report [`Misnested_tag ("body", "p", [("class", "")])].
 
       - [`Bad_content where] is reported by the HTML parser if an element has
         content it is not allowed to have. For example, if there is stray text

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -137,7 +137,7 @@ let tests = [
     expect ~prefix:true "<html><!DOCTYPE html><html></p><head></head></html>"
       [ 1,  1, S (start_element "html");
         1,  7, E (`Bad_document "doctype should be first");
-        1, 22, E (`Misnested_tag ("html", "html"));
+        1, 22, E (`Misnested_tag ("html", "html", []));
         1, 28, E (`Unmatched_end_tag "p");
         1, 32, S (start_element "head")]);
 
@@ -193,8 +193,8 @@ let tests = [
       [ 1,  1, S (start_element "html");
         1,  1, S (start_element "head");
         1,  7, E (`Bad_document "doctype should be first");
-        1, 22, E (`Misnested_tag ("html", "head"));
-        1, 28, E (`Misnested_tag ("head", "head"));
+        1, 22, E (`Misnested_tag ("html", "head", []));
+        1, 28, E (`Misnested_tag ("head", "head", []));
         1, 34, E (`Unmatched_end_tag "p");
         1, 38, S  `End_element;
         1, 45, S (start_element "body")]);
@@ -208,8 +208,8 @@ let tests = [
         1, 14, S (`Text [" "]);
         1, 15, S (`Comment "foo");
         1, 25, E (`Bad_document "doctype should be first");
-        1, 40, E (`Misnested_tag ("html", "html"));
-        1, 46, E (`Misnested_tag ("meta", "html"));
+        1, 40, E (`Misnested_tag ("html", "html", []));
+        1, 46, E (`Misnested_tag ("meta", "html", []));
         1, 46, S (start_element "meta");
         1, 46, S  `End_element;
         1, 52, E (`Bad_document "duplicate head element");
@@ -328,7 +328,7 @@ let tests = [
         1,  1, S (start_element "p");
         1,  4, S  `End_element;
         1,  4, S (start_element "h1");
-        1,  8, E (`Misnested_tag ("h2", "h1"));
+        1,  8, E (`Misnested_tag ("h2", "h1", []));
         1,  8, S  `End_element;
         1,  8, S (start_element "h2");
         1, 12, S (`Text ["foo"]);
@@ -533,19 +533,19 @@ let tests = [
         1, 14, S  `End_element]);
 
   ("html.parser.junk-in-body" >:: fun _ ->
-    expect "<body>\x00<!DOCTYPE html><html><meta><body></body>"
+    expect "<body>\x00<!DOCTYPE html><html><meta><body attr='value'></body>"
       [ 1,  1, S (start_element "html");
         1,  1, S (start_element "head");
         1,  1, S  `End_element;
         1,  1, S (start_element "body");
         1,  7, E (`Bad_token ("U+0000", "body", "null"));
         1,  8, E (`Bad_document "doctype should be first");
-        1, 23, E (`Misnested_tag ("html", "body"));
+        1, 23, E (`Misnested_tag ("html", "body", []));
         1, 29, S (start_element "meta");
         1, 29, S  `End_element;
-        1, 35, E (`Misnested_tag ("body", "body"));
-        1, 48, S  `End_element;
-        1, 48, S  `End_element]);
+        1, 35, E (`Misnested_tag ("body", "body", ["attr", "value"]));
+        1, 61, S  `End_element;
+        1, 61, S  `End_element]);
 
   ("html.parser.nested-html-in-body" >:: fun _ ->
     expect "<div><html></html>foo</div><div>bar</div>"
@@ -554,7 +554,7 @@ let tests = [
         1,  1, S  `End_element;
         1,  1, S (start_element "body");
         1,  1, S (start_element "div");
-        1,  6, E (`Misnested_tag ("html", "body"));
+        1,  6, E (`Misnested_tag ("html", "body", []));
         1,  1, E (`Unmatched_start_tag "div");
         1, 19, E (`Bad_content "html");
         1, 19, S (`Text ["foo"]);
@@ -572,8 +572,8 @@ let tests = [
         1,  1, S  `End_element;
         1,  1, S (start_element "body");
         1,  1, S (start_element "p");
-        1,  4, E (`Misnested_tag ("html", "body"));
-        1, 10, E (`Misnested_tag ("body", "body"));
+        1,  4, E (`Misnested_tag ("html", "body", []));
+        1, 10, E (`Misnested_tag ("body", "body", []));
         1, 16, S  `End_element;
         1, 16, S (start_element "p");
         1, 26, E (`Bad_document ("content after body"));
@@ -888,9 +888,9 @@ let tests = [
       [ 1,  1, S (start_element "head");
         1,  7, S (start_element "noscript");
         1, 17, E (`Bad_document "doctype should be first");
-        1, 32, E (`Misnested_tag ("html", "noscript"));
-        1, 38, E (`Misnested_tag ("head", "noscript"));
-        1, 44, E (`Misnested_tag ("noscript", "noscript"));
+        1, 32, E (`Misnested_tag ("html", "noscript", []));
+        1, 38, E (`Misnested_tag ("head", "noscript", []));
+        1, 44, E (`Misnested_tag ("noscript", "noscript", []));
         1, 54, E (`Unmatched_end_tag "head");
         1, 61, S  `End_element;
         1, 72, S  `End_element]);
@@ -971,7 +971,7 @@ let tests = [
   ("html.parser.nested-button" >:: fun _ ->
     expect ~context:None "<button><button>submit</button></button>"
       [ 1,  1, S (start_element "button");
-        1,  9, E (`Misnested_tag ("button", "button"));
+        1,  9, E (`Misnested_tag ("button", "button", []));
         1,  9, S  `End_element;
         1,  9, S (start_element "button");
         1, 17, S (`Text ["submit"]);
@@ -996,7 +996,7 @@ let tests = [
 
   ("html.parser.nested-achor" >:: fun _ ->
     expect ~context:None "<a><a></a></a>"
-      [ 1,  4, E (`Misnested_tag ("a", "a"));
+      [ 1,  4, E (`Misnested_tag ("a", "a", []));
         1, 11, E (`Unmatched_end_tag "a");
         1,  1, S (start_element "a");
         1,  4, S  `End_element;
@@ -1006,7 +1006,7 @@ let tests = [
   ("html.parser.nested-anchor.reconstruct" >:: fun _ ->
     expect ~context:None "<p><a>foo<a>bar<p>baz"
       [ 1,  1, S (start_element "p");
-        1, 10, E (`Misnested_tag ("a", "a"));
+        1, 10, E (`Misnested_tag ("a", "a", []));
         1, 10, E (`Unmatched_start_tag "a");
         1,  4, S (start_element "a");
         1,  7, S (`Text ["foo"]);
@@ -1024,7 +1024,7 @@ let tests = [
 
   ("html.parser.nested-nobr" >:: fun _ ->
     expect ~context:None "foo<nobr>bar<nobr>baz</nobr>quux</nobr>blah"
-      [ 1, 13, E (`Misnested_tag ("nobr", "nobr"));
+      [ 1, 13, E (`Misnested_tag ("nobr", "nobr", []));
         1, 33, E (`Unmatched_end_tag "nobr");
         1,  1, S (`Text ["foo"]);
         1,  4, S (start_element "nobr");
@@ -1082,15 +1082,15 @@ let tests = [
   ("html.parser.table-content-in-body" >:: fun _ ->
     expect ~context:(Some (`Fragment "body"))
       "<caption><col><colgroup><tbody><td><tfoot><th><thead><tr>"
-      [ 1,  1, E (`Misnested_tag ("caption", "body"));
-        1, 10, E (`Misnested_tag ("col", "body"));
-        1, 15, E (`Misnested_tag ("colgroup", "body"));
-        1, 25, E (`Misnested_tag ("tbody", "body"));
-        1, 32, E (`Misnested_tag ("td", "body"));
-        1, 36, E (`Misnested_tag ("tfoot", "body"));
-        1, 43, E (`Misnested_tag ("th", "body"));
-        1, 47, E (`Misnested_tag ("thead", "body"));
-        1, 54, E (`Misnested_tag ("tr", "body"))]);
+      [ 1,  1, E (`Misnested_tag ("caption", "body", []));
+        1, 10, E (`Misnested_tag ("col", "body", []));
+        1, 15, E (`Misnested_tag ("colgroup", "body", []));
+        1, 25, E (`Misnested_tag ("tbody", "body", []));
+        1, 32, E (`Misnested_tag ("td", "body", []));
+        1, 36, E (`Misnested_tag ("tfoot", "body", []));
+        1, 43, E (`Misnested_tag ("th", "body", []));
+        1, 47, E (`Misnested_tag ("thead", "body", []));
+        1, 54, E (`Misnested_tag ("tr", "body", []))]);
 
   ("html.parser.caption" >:: fun _ ->
     expect ~context:None "<table><caption>foo<p>bar</caption></table>"
@@ -1125,7 +1125,7 @@ let tests = [
     expect ~context:None "<table><td></td></table>"
       [ 1,  1, S (start_element "table");
         1,  8, S (start_element "tbody");
-        1,  8, E (`Misnested_tag ("td", "table"));
+        1,  8, E (`Misnested_tag ("td", "table", []));
         1,  8, S (start_element "tr");
         1,  8, S (start_element "td");
         1, 12, S  `End_element;
@@ -1143,7 +1143,7 @@ let tests = [
   ("html.parser.nested-table" >:: fun _ ->
     expect ~context:None "<table><table></table>"
       [ 1,  1, S (start_element "table");
-        1,  8, E (`Misnested_tag ("table", "table"));
+        1,  8, E (`Misnested_tag ("table", "table", []));
         1,  8, S  `End_element;
         1,  8, S (start_element "table");
         1, 15, S  `End_element]);
@@ -1152,7 +1152,7 @@ let tests = [
     expect ~context:None "<table><caption><caption></caption></table>"
       [ 1,  1, S (start_element "table");
         1,  8, S (start_element "caption");
-        1, 17, E (`Misnested_tag ("caption", "caption"));
+        1, 17, E (`Misnested_tag ("caption", "caption", []));
         1, 17, S  `End_element;
         1, 17, S (start_element "caption");
         1, 26, S  `End_element;
@@ -1200,7 +1200,7 @@ let tests = [
   ("html.parser.form.nested" >:: fun _ ->
     expect ~context:(Some (`Fragment "body")) "<form><form></form>"
       [ 1,  1, S (start_element "form");
-        1,  7, E (`Misnested_tag ("form", "form"));
+        1,  7, E (`Misnested_tag ("form", "form", []));
         1, 13, S  `End_element]
   );
 
@@ -1251,7 +1251,7 @@ let tests = [
     expect ~context:None "<frameset><!DOCTYPE html><html>f"
       [ 1,  1, S (start_element "frameset");
         1, 11, E (`Bad_document "doctype should be first");
-        1, 26, E (`Misnested_tag ("html", "frameset"));
+        1, 26, E (`Misnested_tag ("html", "frameset", []));
         1, 32, E (`Bad_content "frameset");
         1, 33, E (`Unexpected_eoi "frameset");
         1, 33, S  `End_element]);
@@ -1271,19 +1271,19 @@ let tests = [
       [ 1,  1, S (start_element "frameset");
         1, 11, S  `End_element;
         1, 22, E (`Bad_document "doctype should be first");
-        1, 37, E (`Misnested_tag ("html", "html"));
+        1, 37, E (`Misnested_tag ("html", "html", []));
         1, 43, E (`Bad_content "html")]);
 
   ("html.parser.frameset-in-body" >:: fun _ ->
     expect ~context:(Some (`Fragment "body")) "<frameset><p>"
-      [ 1,  1, E (`Misnested_tag ("frameset", "body"));
+      [ 1,  1, E (`Misnested_tag ("frameset", "body", []));
         1, 11, S (start_element "p");
         1, 14, S  `End_element];
 
     expect ~context:None "<body><p><frameset><p></body>"
       [ 1,  1, S (start_element "body");
         1,  7, S (start_element "p");
-        1, 10, E (`Misnested_tag ("frameset", "body"));
+        1, 10, E (`Misnested_tag ("frameset", "body", []));
         1, 20, S  `End_element;
         1, 20, S (start_element "p");
         1, 30, S  `End_element;
@@ -1291,7 +1291,7 @@ let tests = [
 
     expect ~context:None "<p><frameset><p>"
       [ 1,  1, S (start_element "p");
-        1,  4, E (`Misnested_tag ("frameset", "body"));
+        1,  4, E (`Misnested_tag ("frameset", "body", []));
         1, 14, S  `End_element;
         1, 14, S (start_element "p");
         1, 17, S  `End_element];
@@ -1302,7 +1302,7 @@ let tests = [
         1,  1, S  `End_element;
         1,  1, S (start_element "body");
         1,  1, S (start_element "p");
-        1,  4, E (`Misnested_tag ("frameset", "body"));
+        1,  4, E (`Misnested_tag ("frameset", "body", []));
         1,  4, S  `End_element;
         1,  4, S  `End_element;
         1,  4, S (start_element "frameset");


### PR DESCRIPTION
The helper saves a lot of typing and sometimes an extra variable (`name`).

I didn't add the attributes to the error message, which is confusing when different errors are compared in the tests (the messages are the same).

This could work?

~~~
misnested tag: 'body' in 'body' with attributes 'class' = 'whatever', 'id' = 'something'
~~~