### PR TITLE
Added failing test for <rb> tag without surrounding <ruby>

### DIFF
--- a/test/test_integration.ml
+++ b/test/test_integration.ml
@@ -58,6 +58,15 @@ let tests = [
     |> to_list
     |> assert_equal [`Start_element ((Ns.svg, "a"), []); `End_element]);
 
+  ("integration.rb" >:: fun _ ->
+    "<rb>京<rt>きょう"
+    |> string
+    |> parse_html
+    |> signals
+    |> write_html
+    |> to_string
+    |> assert_equal "<ruby><rb>京</rb><rt>きょう</rt></ruby>");
+
   ("integration.pretty_print" >:: fun _ ->
     "<root>foo<nested>bar</nested><nested>baz</nested></root>"
     |> string


### PR DESCRIPTION
I have no idea of why this one raises an error, but I am pretty sure it should not.

No idea if the test is put in the right place either, feel free to rewrite it as you wish.

If you have an idea of where to look at to fix this, I can try, but I am completely lost right now.