### PR TITLE
Fix <form> handling in table and body

### DIFF
--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1121,7 +1121,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
           | _::ancestors -> iterate' ancestors
         in
         iterate' ancestors
-      | {element_name = _, ("tr" | "th")}::_::_ -> in_cell_mode
+      | {element_name = _, ("td" | "th")}::_::_ -> in_cell_mode
       | {element_name = _, "tr"}::_ -> in_row_mode
       | {element_name = _, ("tbody" | "thead" | "tfoot")}::_ ->
         in_table_body_mode

--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -1777,27 +1777,32 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
 
     | l, `End {name = "form"} ->
       if not @@ Stack.has open_elements "template" then begin
-        let form_element = !form_element_pointer in
+        let node = !form_element_pointer in
         form_element_pointer := None;
-        match form_element with
-        | Some element when Stack.target_in_scope open_elements element ->
+        match node with
+        | None ->
+          report l (`Unmatched_end_tag "form") !throw mode
+        | Some element when not (Stack.target_in_scope open_elements element) ->
+          report l (`Unmatched_end_tag "form") !throw mode
+        | Some element -> 
           pop_implied l (fun () ->
           match Stack.current_element open_elements with
           | Some element' when element' == element ->
             pop l mode
           | _ ->
-            report element.location (`Unmatched_start_tag "form") !throw
-              (fun () ->
-            pop_until (fun element' -> element' == element) l (fun () ->
-            pop l mode)))
-        | _ ->
-          report l (`Unmatched_end_tag "form") !throw mode
+            report element.location (`Unmatched_start_tag "form") !throw mode)
       end
-      else
+      else begin
         if not @@ Stack.in_scope open_elements "form" then
           report l (`Unmatched_end_tag "form") !throw mode
         else
-          close_element_with_implied "form" l mode
+          pop_implied l (fun () ->
+            match Stack.current_element open_elements with
+            | Some {element_name = `HTML, "form"} ->
+              pop_until (function {element_name = `HTML, "form"} -> true | _ -> false) l mode
+            | _ ->
+              report l (`Unmatched_end_tag "form") !throw mode)
+      end
 
     | l, `End {name = "p"} ->
       (fun mode' ->
@@ -2162,10 +2167,12 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
       pop l mode))
 
     | l, `Start ({name = "form"} as t) ->
-      misnested_tag l t "table" (fun () ->
-      push_and_emit l t (fun () ->
-      pop l mode))
-
+      if (Stack.has open_elements "template") || !form_element_pointer <> None then
+        misnested_tag l t "table" mode
+      else begin
+        push_and_emit ~set_form_element_pointer:true l t mode;
+        pop l mode
+      end
     | _, `EOF as v ->
       in_body_mode_rules "table" mode v
 

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -1419,6 +1419,16 @@ let tests = [
         1, 13, S  `End_element]
   );
 
+  ("html.parser.form.in-table" >:: fun _ ->
+    expect ~context:(Some (`Fragment "body")) "<form><table><form></table>"
+      [ 1,  1, S (start_element "form");
+        1,  7, S (start_element "table");
+        1, 14, E (`Misnested_tag ("form", "table", []));
+        1, 20, S  `End_element;
+        1, 1, E (`Unmatched_start_tag "form");
+        1, 28, S  `End_element]
+  );
+
   ("html.parser.form.unopened" >:: fun _ ->
     expect ~context:(Some (`Fragment "body")) "</form>"
       [ 1,  1, E (`Unmatched_end_tag "form")]);


### PR DESCRIPTION
We discovered some divergence from spec in `<form>` tag handling and a typo in `reset_mode`, while investigating an edge case where the parser enters an infinite loop (https://github.com/ahrefs/markup.ml/commit/8cca065dd4ca919eb5cbb65069f85fa54e123082). This PR fixes the divergence.


https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intable

> A start tag whose tag name is "form"
> 
> Parse error.
> If there is a template element on the stack of open elements, or if the form element pointer is not null, ignore the token.
> 
> Otherwise:
> Insert an HTML element for the token, and set the form element pointer to point to the element created.
> Pop that form element off the stack of open elements.

https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody


> 
> An end tag whose tag name is "form"
> 
> If there is no template element on the stack of open elements, then run these substeps:
> 
> Let node be the element that the form element pointer is set to, or null if it is not set to an element.
>   Set the form element pointer to null.
>   If node is null or if the stack of open elements does not have node in scope, then this is a parse error; return and ignore the token.
>   Generate implied end tags.
>   If the current node is not node, then this is a parse error.
>   Remove node from the stack of open elements.
> 
> If there is a template element on the stack of open elements, then run these substeps instead:
>   If the stack of open elements does not have a form element in scope, then this is a parse error; return and ignore the token.
>   Generate implied end tags.
>   If the current node is not a form element, then this is a parse error.
>   Pop elements from the stack of open elements until a form element has been popped from the stack.

