### PR TITLE
Fix <template> parsing

### DIFF
--- a/src/html_parser.ml
+++ b/src/html_parser.ml
@@ -2546,7 +2546,7 @@ let parse requested_context report (tokens, set_tokenizer_state, set_foreign) =
 
   (* 8.2.5.4.18. *)
   and in_template_mode () =
-    dispatch tokens (fun v -> in_table_mode_rules in_template_mode v)
+    dispatch tokens (fun v -> in_template_mode_rules in_template_mode v)
 
   (* 8.2.5.4.18. *)
   and in_template_mode_rules mode = function

--- a/test/test_html_parser.ml
+++ b/test/test_html_parser.ml
@@ -1524,5 +1524,16 @@ let tests = [
         1, 14, S (start_element "frame");
         1, 14, S  `End_element;
         1, 21, S  `End_element;
-        1, 32, S  `End_element])
+        1, 32, S  `End_element]);
+
+  ("html.parser.template" >:: fun _ ->
+    expect ~context:None "<template></template>"
+      [ 1,  1, S (start_element "template");
+        1, 11, S  `End_element];
+
+    expect ~context:None "<template><p></p></template>"
+      [ 1,  1, S (start_element "template");
+        1, 11, S (start_element "p");
+        1, 14, S  `End_element;
+        1, 18, S  `End_element]);
 ]


### PR DESCRIPTION
Looks like the table mode rules were used instead of the template mode rules, causing templates to be parsed incorrectly.